### PR TITLE
Update driver location & mention Enveigle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ This assumes your Trellis directory structure looks like:
             ├── app/  # → WordPress content directory (themes, plugins, etc.)
             └── wp/   # → WordPress core (don't touch!)
 
-If you're migrating from Trellis, you'll need to create a `site/.env` file. See [here](https://roots.io/bedrock/docs/environment-variables/) for more information. [TangRufus](https://github.com/TangRufus) has written [Enveigle](https://github.com/ItinerisLtd/enveigle) which creates Bedrock's .env file from the settings in your `/trellis/group_vars/` directory. Useful if you're joining an existing Trellis project or want to use Trellis for deploys.
+If you're migrating from Trellis, you'll need to create a `site/.env` file. See [here](https://roots.io/bedrock/docs/environment-variables/) for more information. [TangRufus](https://github.com/TangRufus) has written [Enveigle](https://github.com/ItinerisLtd/enveigle) which creates `site/.env` file from the settings in your `/trellis/group_vars/` directory.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ install.
 
 ## Installing
 
-Download `TrellisValetDriver.php` and place it in your `~/.valet/Drivers` folder. Now your Trellis/Bedrock folders will display correctly - no configuration required.
+Download `TrellisValetDriver.php` and place it in your `~/.config/Valet/Drivers` folder. Now your Trellis/Bedrock folders will display correctly - no configuration required.
 
 This assumes your Trellis directory structure looks like:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ install.
 
 ## Installing
 
-Download `TrellisValetDriver.php` and place it in your `~/.config/Valet/Drivers` folder. Now your Trellis/Bedrock folders will display correctly - no configuration required.
+Download `TrellisValetDriver.php` and place it in your `~/.config/valet/Drivers` folder. Now your Trellis/Bedrock folders will display correctly - no configuration required.
 
 This assumes your Trellis directory structure looks like:
 
@@ -17,4 +17,4 @@ This assumes your Trellis directory structure looks like:
             ├── app/  # → WordPress content directory (themes, plugins, etc.)
             └── wp/   # → WordPress core (don't touch!)
 
-If you're migrating from Trellis, you'll need to create a `site/.env` file. See [here](https://roots.io/bedrock/docs/environment-variables/) for more information.
+If you're migrating from Trellis, you'll need to create a `site/.env` file. See [here](https://roots.io/bedrock/docs/environment-variables/) for more information. [TangRufus](https://github.com/TangRufus) has written [Enveigle](https://github.com/ItinerisLtd/enveigle) which creates Bedrock's .env file from the settings in your `/trellis/group_vars/` directory. Useful if you're joining an existing Trellis project or want to use Trellis for deploys.


### PR DESCRIPTION
Valet now seems to install drivers at `~/.config/valet/Drivers` rather than in `~/.valet/Drivers`. I updated the readme.md to reflect this, and also added a link to TangRufus' Enveigle which creates the .env file from vars already used in Trellis.

Feedback/comments welcome...